### PR TITLE
Add pycrypto as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     ],
     install_requires=[
         'XBlock',
+        'pycrypto'
     ],
     entry_points={
         'xblock.v1': [


### PR DESCRIPTION
### Description

`Crypto` modules requires `pycrypto` package to be installed. If we just install this module as it is now, system is crashed at start and `pycrypto` must be installed manually.